### PR TITLE
Removed large paragraphs and provided links to module documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,26 +41,14 @@ Stetho Init isn't expected to break, but there's no guarantees.
 ## App Context
 *Have a `Context` everywhere.*
 
-Designed for Kotlin.
-### Why?
-I was tired of searching for a reference to the current context everytime, and tired of not being able to use it in Kotlin's `object` singletons, so I found a safe way to have a reference to the application Context everywhere.
-### Usage
-When you don't need configuration dependent or themed `Context`, just use `appCtx` from any Kotlin code to get a reference to your application Context. This library also provides a lazily initialized `directBootCtx` for direct boot aware apps.
+Designed for Kotlin. When you don't need configuration dependent or themed `Context`, just use `appCtx` from any Kotlin code to get a reference to your application Context. This library also provides a lazily initialized `directBootCtx` for direct boot aware apps.
 
 [Read more here](appctx/README.md)
 
 ## Concurrency
 *Single thread `lazy` implementations, with reporting via [Timber](https://github.com/JakeWharton/timber) support.*
 
-Designed for Kotlin.
-### What it does
-Provides `lazy` implementations that can check for access on single thread or UI thread.
-
-Also provides the `mainLooper` and `isUiThread` properties.
-
-### Usage
-Write `lazy` as usual, but make sure you have `import splitties.concurrency.lazy` in your imports. If not, you're using the wrong implementation. Note that you can still use regular lazy implementations with this import thanks to inline proxy function to Kotlin's stdlib lazy methods.
-You can customize the behavior when a violation occurs. The default one is to throw and `IllegalStateException` but as it's done in the sample, you can change it to report using [Timber](https://github.com/JakeWharton/timber) or to ignore it. When using the report mode, it's easy to forward it to your favorite error reporting system such as [Firebase Crash Reporting](https://firebase.google.com/docs/crash/) using a custom Timber Tree.
+Designed for Kotlin. Provides `lazy` implementations that can check for access on single thread or UI thread. Also provides the `mainLooper` and `isUiThread` properties.
 
 [Read more here](concurrency/README.md)
 
@@ -71,8 +59,7 @@ You can customize the behavior when a violation occurs. The default one is to th
 
 Written in Java only, but the simple API is Kotlin friendly. Uses ConstraintLayout and LinearLayout.
 
-You can directly use the layout files.
-Not all lists items documented in the guidelines are implemented for now. If you want another one not implemented, please, file an issue.
+You can directly use the layout files. Not all lists items documented in the guidelines are implemented for now. If you want another one that is not implemented, please, file an issue.
 
 The goal of this library is to finally provide the most efficient and lightweight implementation for all [list items](https://material.io/guidelines/components/lists.html) and [list control](https://material.io/guidelines/components/lists-controls.html) items described in the Material Design Guidelines.
 
@@ -83,12 +70,14 @@ Here are the available list items:
 * `R.layout.list_item_two_lines_icon_switch`
 * `R.layout.list_item_two_lines_icon`
 
-See an example in the sample.
+See an example in the sample module.
+
+[Read more here](material-lists/README.md)
 
 ## Preferences
 *Property syntax for Android's SharedPreferences.*
 
-For use in Kotlin.
+For use in Kotlin. This library uses Kotlin's property delegation to make using SharedPreferences as easy as accessing a property on an object. It relies on the `appCtx` module of this library to allow usage in `object` in Kotlin, and can support storage on device encrypted storage for devices supporting Direct Boot. See [the source code](preferences/src/main/java/splitties/preferences) for more information
 
 ### Usage
 Define your preferences in an `object` or a `class` like in the example below:
@@ -103,15 +92,15 @@ object GamePreferences : Preferences("gameState") {
     var pseudo by StringPref("playerPseudo", "Player 1")
 }
 ```
-### How it works
-This library uses Kotlin's property delegation to make using SharedPreferences as easy as accessing a property on an object. It relies on the `appCtx` module of this library to allow usage in `object` in Kotlin, and can support storage on device encrypted storage for devices supporting Direct Boot. See [the source code](preferences/src/main/java/splitties/preferences) for more information
 
 ## Selectable Views
 *Selectable TextView, ViewGroups and RecyclerView list items made easy.*
 
 Made in Java. Works exactly the same in Kotlin.
+
 ### What it does
 It adds a `foreground` attribute to `TextView` and common ViewGroups (`ConstraintLayout`, `LinearLayout` and `RelativeLayout`) which defaults to `@android:attr/selectableItemBackground`, allowing visual feedback when the user selects the View. This can be useful in a `RecyclerView`.
+
 ### Usage
 Just use `SelectableLinearLayout`, `SelectableRelativeLayout` or `SelectableConstraintLayout` in your layouts, or extend them, and if you want to customize the foreground, follow this example:
 ```xml
@@ -122,6 +111,7 @@ Just use `SelectableLinearLayout`, `SelectableRelativeLayout` or `SelectableCons
 </SelectableConstraintLayout>
 ```
 Note that the `foreground` atrribute does not clash with android's one (for API 23+), and applies to subclasses.
+
 ### Explanation
 `FrameLayout` is historically the only `ViewGroup` which supports a foreground drawable attribute. The foreground attribute is often used with value `@android:attr/selectableItemBackground` to provide visual feedback when the user touches a selectable element such as a list item in a RecyclerView, which translates as a Ripple effect starting from Android Lollipop. As a consequence, people usually wrap their `RelativeLayout`, `LinearLayout` or other `ViewGroup` with a `FrameLayout` just to provide this foreground attribute. This is unefficient, espacially if this is replicated as it is in a RecyclerView. The foreground attribute is part of the `View` class since Android Marshmallow now, but few apps can have their minSdk set to 23, so I made this library which provides a `foreground` attribute that defaults to `@android:attr/selectableItemBackground` for popular `ViewGroups` and `TextView`.
 
@@ -129,8 +119,10 @@ Note that the `foreground` atrribute does not clash with android's one (for API 
 *Have [Stetho](https://github.com/facebook/stetho) without writing any code!*
 
 Made in Java (because using Kotlin here would be overkill).
+
 ### What it does
 This library uses a Content Provider (like Firebase) to initialize Stetho automatically. You just have to include the dependency on your debug build and voilà!
+
 ### Usage
 Just add the dependency to your debug build like in the example below:
 ```groovy
@@ -139,11 +131,14 @@ debugCompile "xyz.louiscad.splitties:splitties-stetho-init:$splittiesVersion"
 
 ## Typesafe RecyclerView
 Written in Kotlin and Java. Works similarly in both languages.
+
 ### What it does
 It makes using RecyclerView simpler, with less boilerplate for basic or less basic usages.
+
 ### Usage
 Download or clone the project and open it in Android Studio to see the sample. Alternatively, take a look at these classes:
 [DemoAdapter](https://github.com/LouisCAD/Splitties/blob/master/sample/src/main/java/xyz/louiscad/splittiessample/ui/adapter/DemoAdapter.java), [DemoListItem](https://github.com/LouisCAD/Splitties/blob/master/sample/src/main/java/xyz/louiscad/splittiessample/ui/widget/DemoListItem.java), [DemoItem](https://github.com/LouisCAD/Splitties/blob/master/sample/src/main/java/xyz/louiscad/splittiessample/ui/model/DemoItem.java) and [ImmutableBasicItem](https://github.com/LouisCAD/Splitties/blob/master/sample/src/main/java/xyz/louiscad/splittiessample/ui/model/ImmutableBasicItem.java).
+
 ### Explanation
 This modules consists of two `ViewHolder` subclasses that make it typesafe, and easier to use for the common use case which is to bind a ViewHolder to a POJO. See the sample to understand how it works.
 


### PR DESCRIPTION
I did this for modules that have READMEs, but left it for the ones that did not yet. Will be filing a separate issue to document those. This is for #6.