### PR TITLE
Check and publish from GitHub actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [gradlew.bat]
 end_of_line = crlf
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -15,7 +15,7 @@ on:
       - '**.md'
       - '**.adoc'
 jobs:
-  gradle:
+  run-tests:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -27,4 +27,4 @@ jobs:
           java-version: 11
       - uses: eskatos/gradle-command-action@v1
         with:
-          arguments: --scan test
+          arguments: --scan test allTests

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -8,6 +8,9 @@ on:
       - '**.md'
       - '**.adoc'
   push:
+    branches:
+      - develop
+      - master
     paths-ignore:
       - '**.md'
       - '**.adoc'

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -15,18 +15,16 @@ on:
       - '**.md'
       - '**.adoc'
 jobs:
-  run-tests:
+  gradle:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
-      - name: Setup SDK
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Gradle test
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: --scan test

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -15,16 +15,18 @@ on:
       - '**.md'
       - '**.adoc'
 jobs:
-  gradle:
+  run-tests:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
+      - name: Setup SDK
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Gradle test
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: --scan test

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -18,7 +18,7 @@ jobs:
   gradle:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -2,25 +2,25 @@
 # https://github.com/marketplace/actions/gradle-command
 name: Check build and run tests
 on:
-    pull_request:
-        paths-ignore:
-            - '**.md'
-            - '**.adoc'
-    push:
-        paths-ignore:
-            - '**.md'
-            - '**.adoc'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.adoc'
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.adoc'
 jobs:
-    gradle:
-        strategy:
-            matrix:
-                os: [ubuntu-latest]
-        runs-on: ${{ matrix.os }}
-        steps:
-            - uses: actions/checkout@v1
-            - uses: actions/setup-java@v1
-                with:
-                    java-version: 11
-            - uses: eskatos/gradle-command-action@v1
-                with:
-                    arguments: --scan testDebugUnitTest
+  gradle:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: --scan testDebugUnitTest

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,7 +1,7 @@
 # https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 # https://github.com/marketplace/actions/gradle-command
 name: Gradle 5.6.3
-on: [pull_request]
+on: [pull_request, push]
 jobs:
     gradle:
         strategy:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,0 +1,19 @@
+# https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+# https://github.com/marketplace/actions/gradle-command
+name: Gradle 5.6.3
+on: [pull_request]
+jobs:
+    gradle:
+        strategy:
+            matrix:
+                os: [ubuntu-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions/setup-java@v1
+              with:
+                  java-version: 8
+            - uses: eskatos/gradle-command-action@v1
+              with:
+                  gradle-version: 5.6.3
+                  arguments: --scan testDebugUnitTest

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,6 +1,6 @@
 # https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 # https://github.com/marketplace/actions/gradle-command
-name: Gradle 5.6.3
+name: Check build and run tests
 on: [pull_request, push]
 jobs:
     gradle:
@@ -15,5 +15,4 @@ jobs:
                   java-version: 8
             - uses: eskatos/gradle-command-action@v1
               with:
-                  gradle-version: 5.6.3
                   arguments: --scan testDebugUnitTest

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -18,11 +18,9 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v1
-            - name: Setup JDK
             - uses: actions/setup-java@v1
-              with:
-                  java-version: 11
-            - name: Run Gradle task
+                with:
+                    java-version: 11
             - uses: eskatos/gradle-command-action@v1
-              with:
-                  arguments: --scan testDebugUnitTest
+                with:
+                    arguments: --scan testDebugUnitTest

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -3,6 +3,7 @@
 name: Check build and run tests
 on:
   pull_request:
+    types: [assigned, opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - '**.adoc'

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,7 +1,15 @@
 # https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 # https://github.com/marketplace/actions/gradle-command
 name: Check build and run tests
-on: [pull_request, push]
+on:
+    pull_request:
+        paths-ignore:
+            - '**.md'
+            - '**.adoc'
+    push:
+        paths-ignore:
+            - '**.md'
+            - '**.adoc'
 jobs:
     gradle:
         strategy:
@@ -10,9 +18,11 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v1
+            - name: Setup JDK
             - uses: actions/setup-java@v1
               with:
-                  java-version: 8
+                  java-version: 11
+            - name: Run Gradle task
             - uses: eskatos/gradle-command-action@v1
               with:
                   arguments: --scan testDebugUnitTest

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -24,4 +24,4 @@ jobs:
           java-version: 11
       - uses: eskatos/gradle-command-action@v1
         with:
-          arguments: --scan testDebugUnitTest
+          arguments: --scan test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
 # https://github.com/marketplace/actions/gradle-command
-name: On release
+name: Publish to repository
 on:
     push:
         branches:
@@ -22,5 +22,4 @@ jobs:
                   java-version: 11
             - uses: eskatos/gradle-command-action@v1
               with:
-                  gradle-version: 5.6.3
                   arguments: --scan --dry-run publishToRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,24 +2,43 @@
 # https://github.com/marketplace/actions/gradle-command
 name: Publish to repository
 on:
-    push:
+    pull_request:
+        paths:
+            - 'libraries_version.properties'
         branches:
             - master
             - develop
-    release:
-        # Only use the types keyword to narrow down the activity types that will trigger your workflow.
-        types: [published, created, edited]
+    push:
+        paths:
+            - 'libraries_version.properties'
+        branches:
+            - master
+            - develop
 jobs:
-    gradle:
+    mac-and-windows-publishing:
         strategy:
             matrix:
-                os: [ubuntu-latest, windows-latest, macOS-latest]
+                os: [macOS-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v1
+            - name: Setup JDK
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
+            - name: Run Gradle task
             - uses: eskatos/gradle-command-action@v1
               with:
-                  arguments: --scan --dry-run publishToRepository
+                  arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan publishToRepository
+    linux-and-mpp-publishing:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v1
+            - name: Setup JDK
+            - uses: actions/setup-java@v1
+                with:
+                    java-version: 11
+            - name: Run Gradle task
+            - uses: eskatos/gradle-command-action@v1
+                with:
+                    arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan -Pmpp.publishAll=true publishToRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
-      - name: Setup SDK
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Gradle test
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan publishToRepository
@@ -28,11 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Setup SDK
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Gradle test
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan -Pmpp.publishAll=true publishToRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,9 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v1
-            - name: Setup JDK
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - name: Run Gradle task
             - uses: eskatos/gradle-command-action@v1
               with:
                   arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan publishToRepository
@@ -34,11 +32,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
-            - name: Setup JDK
             - uses: actions/setup-java@v1
                 with:
                     java-version: 11
-            - name: Run Gradle task
             - uses: eskatos/gradle-command-action@v1
                 with:
                     arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan -Pmpp.publishAll=true publishToRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
-          with:
-            java-version: 11
+        with:
+          java-version: 11
       - uses: eskatos/gradle-command-action@v1
-          with:
-            arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan -Pmpp.publishAll=true publishToRepository
+        with:
+          arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan -Pmpp.publishAll=true publishToRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+# https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+# https://github.com/marketplace/actions/gradle-command
+name: On release
+on:
+    push:
+        branches:
+            - master
+            - develop
+    release:
+        # Only use the types keyword to narrow down the activity types that will trigger your workflow.
+        types: [published, created, edited]
+jobs:
+    gradle:
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest, macOS-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions/setup-java@v1
+              with:
+                  java-version: 11
+            - uses: eskatos/gradle-command-action@v1
+              with:
+                  gradle-version: 5.6.3
+                  arguments: --scan --dry-run publishToRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,6 @@
 # https://github.com/marketplace/actions/gradle-command
 name: Publish to repository
 on:
-  pull_request:
-    paths:
-      - 'libraries_version.properties'
-    branches:
-      - master
-      - develop
   push:
     paths:
       - 'libraries_version.properties'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
+      - name: Setup SDK
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Gradle test
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan publishToRepository
@@ -26,9 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Setup SDK
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Gradle test
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan -Pmpp.publishAll=true publishToRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,39 +2,39 @@
 # https://github.com/marketplace/actions/gradle-command
 name: Publish to repository
 on:
-    pull_request:
-        paths:
-            - 'libraries_version.properties'
-        branches:
-            - master
-            - develop
-    push:
-        paths:
-            - 'libraries_version.properties'
-        branches:
-            - master
-            - develop
+  pull_request:
+    paths:
+      - 'libraries_version.properties'
+    branches:
+      - master
+      - develop
+  push:
+    paths:
+      - 'libraries_version.properties'
+    branches:
+      - master
+      - develop
 jobs:
-    mac-and-windows-publishing:
-        strategy:
-            matrix:
-                os: [macOS-latest, windows-latest]
-        runs-on: ${{ matrix.os }}
-        steps:
-            - uses: actions/checkout@v1
-            - uses: actions/setup-java@v1
-              with:
-                  java-version: 11
-            - uses: eskatos/gradle-command-action@v1
-              with:
-                  arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan publishToRepository
-    linux-and-mpp-publishing:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v1
-            - uses: actions/setup-java@v1
-                with:
-                    java-version: 11
-            - uses: eskatos/gradle-command-action@v1
-                with:
-                    arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan -Pmpp.publishAll=true publishToRepository
+  mac-and-windows-publishing:
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan publishToRepository
+  linux-and-mpp-publishing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+          with:
+            java-version: 11
+      - uses: eskatos/gradle-command-action@v1
+          with:
+            arguments: -Pbintray_user=${{ secrets.bintray_user }} -Pbintray_api_key=${{ secrets.bintray_api_key }} --scan -Pmpp.publishAll=true publishToRepository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,6 +9,7 @@ with `kotlinc -script Releasing.kts` and follow the steps directly from the comm
 
 ## Publishing a dev version
 
-1. Make sure `splitties.version` in the [gradle.properties](gradle.properties) file is
+1. Make sure `splitties.version` in the [libraries_version.properties](libraries_version.properties) file is
 set to a `-dev-` version.
 2. Run `./gradlew clean bintrayUpload`.
+<!-- TODO: The step above is obsolete is set to be replaced by a GitHub Action -->

--- a/Releasing.kts
+++ b/Releasing.kts
@@ -144,7 +144,7 @@ var newVersion: String //TODO: Make a val again when https://youtrack.jetbrains.
 var startAtStep: BintrayReleaseStep //TODO: Make a val again when https://youtrack.jetbrains.com/issue/KT-20059 is fixed
 
 val ongoingReleaseFile = dir.resolve("ongoing_release.splitties")
-val versionsFile = dir.resolve("gradle.properties")
+val versionsFile = dir.resolve("libraries_version.properties")
 val libVersionLineStart = "splitties.version="
 
 if (ongoingReleaseFile.exists()) {
@@ -217,6 +217,7 @@ fun runBintrayReleaseStep(step: BintrayReleaseStep) = when (step) {
         "git tag -a v$newVersion -m \"Version $newVersion\"".executeAndPrint()
     }
     CLEAN_AND_UPLOAD -> {
+        TODO("This step is obsolete is set to be replaced by a GitHub Action")
         val cleanAndUploadCommand = "./gradlew clean bintrayUpload"
         printInfo("Running `$cleanAndUploadCommand`")
         cleanAndUploadCommand.executeAndPrint()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
      * See "settings.gradle.kts"
      */
     id("de.fayard.refreshVersions")
-    id ("com.gradle.build-scan")
+    `build-scan`
 }
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,13 @@ Libs.kotlinVersion = "1.3.50"
 
 
 allprojects {
+    tasks.whenTaskAdded {
+        if("DebugUnitTest" in name || "ReleaseUnitTest" in name) {
+            enabled = false
+            // MPP + Android unit testing is so broken we just disable it altogether,
+            // (discussion here https://kotlinlang.slack.com/archives/C3PQML5NU/p1572168720226200)
+        }
+    }
     repositories {
         setupForProject()
     }
@@ -47,7 +54,7 @@ buildSrcVersions {
 
 /**
 For investigating build issue and bug reports, run
-  ./gradlew --scan $TASKNAME
+./gradlew --scan $TASKNAME
 see https://dev.to/jmfayard/the-one-gradle-trick-that-supersedes-all-the-others-5bpg
  **/
 buildScan {

--- a/buildSrc/src/main/kotlin/config/KotlinSourceSetsConfig.kt
+++ b/buildSrc/src/main/kotlin/config/KotlinSourceSetsConfig.kt
@@ -279,7 +279,7 @@ private fun NamedDomainObjectContainer<KotlinSourceSet>.createMainAndTest(
         configureAction(false)
     }
     val testSourceSet = create("${name}Test").apply {
-        dependsOn(mainSourceSet)
+        //dependsOn(mainSourceSet)
         dependsOn.forEach { getByName("${it}Test") }
         configureAction(true)
     }

--- a/buildSrc/src/main/kotlin/config/KotlinSourceSetsConfig.kt
+++ b/buildSrc/src/main/kotlin/config/KotlinSourceSetsConfig.kt
@@ -279,7 +279,6 @@ private fun NamedDomainObjectContainer<KotlinSourceSet>.createMainAndTest(
         configureAction(false)
     }
     val testSourceSet = create("${name}Test").apply {
-        //dependsOn(mainSourceSet)
         dependsOn.forEach { getByName("${it}Test") }
         configureAction(true)
     }

--- a/buildSrc/src/main/kotlin/config/KotlinSourceSetsConfig.kt
+++ b/buildSrc/src/main/kotlin/config/KotlinSourceSetsConfig.kt
@@ -22,12 +22,37 @@ import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 import org.jetbrains.kotlin.konan.target.Family
 import org.jetbrains.kotlin.konan.target.HostManager
 
+fun KotlinTargetContainerWithPresetFunctions.linux(
+    x64: Boolean = false,
+    arm32Hfp: Boolean = false,
+    arm64: Boolean = false,
+    mips32: Boolean = false,
+    mipsel32: Boolean = false
+) {
+    if (HostManager.hostIsLinux.not() && isRunningInIde) return
+    if (x64) linuxX64()
+    if (arm32Hfp) linuxArm32Hfp()
+    if (arm64) linuxArm64()
+    if (mips32) linuxMips32()
+    if (mipsel32) linuxMipsel32()
+}
+
+fun KotlinTargetContainerWithPresetFunctions.mingw(
+    x64: Boolean = false,
+    x86: Boolean = false
+) {
+    if (HostManager.hostIsMingw.not() && isRunningInIde) return
+    if (x64) mingwX64()
+    if (x86) mingwX86()
+}
+
 fun KotlinTargetContainerWithPresetFunctions.macos() {
-    if (HostManager.hostIsMac) macosX64()
+    if (HostManager.hostIsMac.not() && isRunningInIde) return
+    macosX64()
 }
 
 fun KotlinTargetContainerWithPresetFunctions.ios() {
-    if (HostManager.hostIsMac.not()) return
+    if (HostManager.hostIsMac.not() && isRunningInIde) return
     if (isRunningInIde) {
         if (use32bitsInIde) iosArm32() else iosX64()
     } else iosAll()

--- a/buildSrc/src/main/kotlin/config/ProjectVersions.kt
+++ b/buildSrc/src/main/kotlin/config/ProjectVersions.kt
@@ -5,11 +5,24 @@
 @file:Suppress("PackageDirectoryMismatch")
 
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.extra
+import java.util.Properties
 
 object ProjectVersions {
     const val androidBuildTools = "28.0.3"
     const val androidSdk = 28
 }
 
-val Project.thisLibraryVersion: String get() = property("splitties.version") as String
+val Project.thisLibraryVersion: String
+    get() {
+        val key = "splitties.version"
+        return rootProject.extra.properties.getOrElse(key) {
+            Properties().also {
+                it.load(rootProject.file("libraries_version.properties").reader())
+            }.getProperty(key).also { value ->
+                rootProject.extra.properties[key] = value // Cache it in root project's extra properties.
+            }
+        } as String
+    }
+
 val Project.isDevVersion get() = thisLibraryVersion.contains("-dev-")

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,7 @@ kotlin.native.ignoreDisabledTargets=true
 
 android.namespacedRClass=true
 
+mpp.publishAll=false
 splitties.version=3.0.0-dev-038
 
 # The plugin https://github.com/jmfayard/buildSrcVersions

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,6 @@ kotlin.native.ignoreDisabledTargets=true
 android.namespacedRClass=true
 
 mpp.publishAll=false
-splitties.version=3.0.0-dev-038
 
 # The plugin https://github.com/jmfayard/buildSrcVersions
 # allows to overwrite plugin and dependencies versions from the values inside 'gradle.properties'

--- a/libraries_version.properties
+++ b/libraries_version.properties
@@ -1,0 +1,8 @@
+#
+# Copyright 2019 Louis Cognault Ayeva Derman. Use of this source code is governed by the Apache 2.0 license.
+#
+
+# suppress inspection "UnusedProperty" for whole file
+# (used in ProjectVersions.kt)
+
+splitties.version=3.0.0-dev-038

--- a/libraries_version.properties
+++ b/libraries_version.properties
@@ -5,4 +5,4 @@
 # suppress inspection "UnusedProperty" for whole file
 # (used in ProjectVersions.kt)
 
-splitties.version=3.0.0-dev-038
+splitties.version=3.0.0-dev-040

--- a/modules/checkedlazy/src/androidTest/kotlin/splitties/checkedlazy/CheckedLazyFunctionalTest.kt
+++ b/modules/checkedlazy/src/androidTest/kotlin/splitties/checkedlazy/CheckedLazyFunctionalTest.kt
@@ -4,12 +4,15 @@
 
 package splitties.checkedlazy
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import org.junit.runner.RunWith
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
+@RunWith(AndroidJUnit4::class)
 class CheckedLazyFunctionalTest {
 
     @Test

--- a/modules/collections/build.gradle.kts
+++ b/modules/collections/build.gradle.kts
@@ -12,8 +12,8 @@ kotlin {
     js()
     macos()
     ios()
-    linuxX64()
-    mingwX64()
+    linux(x64 = true)
+    mingw(x64 = true)
     configure(targets) { configureMavenPublication() }
     setupSourceSets()
     sourceSets {

--- a/modules/mainthread/src/androidTest/kotlin/splitties/mainthread/MainThreadCheckFunctionalTest.kt
+++ b/modules/mainthread/src/androidTest/kotlin/splitties/mainthread/MainThreadCheckFunctionalTest.kt
@@ -5,14 +5,17 @@
 package splitties.mainthread
 
 import android.os.Looper
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
+@RunWith(AndroidJUnit4::class)
 class MainThreadCheckFunctionalTest {
 
     @Test

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -1,3 +1,4 @@
 /build
 /.gradle
 /.idea
+.kotlintest

--- a/test-helpers/build.gradle.kts
+++ b/test-helpers/build.gradle.kts
@@ -20,8 +20,8 @@ kotlin {
     js()
     macos()
     ios()
-    if (isRunningInIde.not() || HostManager.hostIsLinux) linuxX64()
-    if (isRunningInIde.not() || HostManager.hostIsMingw) mingwX64()
+    linux(x64 = true)
+    mingw(x64 = true)
     setupSourceSets()
     sourceSets {
         commonMain.dependencies {

--- a/test-helpers/build.gradle.kts
+++ b/test-helpers/build.gradle.kts
@@ -2,8 +2,6 @@
  * Copyright 2019 Louis Cognault Ayeva Derman. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import org.jetbrains.kotlin.konan.target.HostManager
-
 plugins {
     id("com.android.library")
     kotlin("multiplatform")


### PR DESCRIPTION
Closes #218 

The `publishToRepository` task allows to publish all the Kotlin/Native artifacts that belong to the host (i.e. linux on Linux host, Mingw on Windows host, and iOS/macOS/watchOS/tvOS on macOS host).

To enable the publication of the targets that can be built from any host (JVM, JS, Android, Kotlin metadata/common and Kotlin multiplatform), the property named `mpp.publishAll` needs to be set to `true` (defaults to `false`).

AFAIK, the most cost efficient build machines run Linux, so I plan to enable `mpp.publishAll` when running on Linux, and use other hosts only for builds that Linux can't run.