### PR TITLE
match/wrap: replaced inline getter with const val

### DIFF
--- a/modules/views-dsl/src/androidMain/kotlin/splitties/views/dsl/core/LayoutParams.kt
+++ b/modules/views-dsl/src/androidMain/kotlin/splitties/views/dsl/core/LayoutParams.kt
@@ -12,13 +12,11 @@ import android.view.ViewGroup
  * visible inside [ViewGroup]s.
  */
 @Suppress("unused")
-inline val View.matchParent
-    get() = ViewGroup.LayoutParams.MATCH_PARENT
+const val View.matchParent: Int = ViewGroup.LayoutParams.MATCH_PARENT
 
 /**
  * **A LESS CAPITALIZED ALIAS** to [ViewGroup.LayoutParams.WRAP_CONTENT] that is only
  * visible inside [ViewGroup]s.
  */
 @Suppress("unused")
-inline val View.wrapContent
-    get() = ViewGroup.LayoutParams.WRAP_CONTENT
+const val View.wrapContent: Int = ViewGroup.LayoutParams.WRAP_CONTENT


### PR DESCRIPTION
This removes extra getters but the properties are still inline because they are `const`.