### PR TITLE
Make getSystemService nulllable in SafeToastCtx

### DIFF
--- a/modules/toast/src/androidMain/kotlin/splitties/toast/Toast.kt
+++ b/modules/toast/src/androidMain/kotlin/splitties/toast/Toast.kt
@@ -93,7 +93,7 @@ private class SafeToastCtx(ctx: Context) : ContextWrapper(ctx) {
     }
 
     override fun getApplicationContext(): Context = SafeToastCtx(baseContext.applicationContext)
-    override fun getSystemService(name: String): Any = when (name) {
+    override fun getSystemService(name: String): Any? = when (name) {
         Context.LAYOUT_INFLATER_SERVICE -> toastLayoutInflater
         Context.WINDOW_SERVICE -> toastWindowManager
         else -> super.getSystemService(name)


### PR DESCRIPTION
Make getSystemService nulllable in `SafeToastCtx`.
This fixes a crash when `super.getSystemService` returns null (accessing non-existent system service)